### PR TITLE
docs: document desktop startup sequence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,50 @@
+# Architecture and Dependency Management
+
+This index links to dedicated specification documents that describe each major subsystem involved in launching and operating ComfyUI. Use these specs to understand how the runtime is assembled, how assets are organised, and how the server communicates with bundled frontends.
+
+## Runtime Lifecycle
+- [Runtime Initialization Specification](docs/specs/runtime_initialization.md) — step-by-step breakdown of `main.py`, covering CLI parsing, environment setup, custom node loading, device selection, prompt queue threading, and shutdown hygiene.【F:main.py†L1-L369】
+- [Desktop Startup Sequence Specification](docs/specs/desktop_startup_sequence.md) — chronicles how bundled launchers bring up the embedded Python runtime, validate dependencies, construct the prompt server, and signal the frontend when the UI is ready to render.【F:requirements.txt†L1-L30】【F:main.py†L1-L369】【F:server.py†L162-L986】
+- [Prompt Server Specification](docs/specs/prompt_server_spec.md) — explains aiohttp middleware, websocket negotiation, REST endpoints, and how the `PromptQueue` interfaces with the worker thread.【F:server.py†L1-L371】【F:main.py†L168-L243】
+
+## Asset and Model Handling
+- [Model and Asset Management Specification](docs/specs/model_asset_management.md) — documents the directory schema defined in `folder_paths.py`, override mechanisms, cache helpers, and how extra model paths integrate into bundled installs.【F:folder_paths.py†L1-L214】【F:extra_model_paths.yaml.example†L1-L47】【F:main.py†L25-L57】
+
+## Python Environment Expectations
+- [Python Environment and Dependency Specification](docs/specs/python_environment_spec.md) — details the supported interpreter versions, pinned dependencies, frontend wheel enforcement, and accelerator-specific install paths that all distributions must respect.【F:main.py†L353-L360】【F:requirements.txt†L1-L30】【F:app/frontend_management.py†L1-L81】【F:README.md†L191-L315】
+- [Hardware Support Specification](docs/specs/hardware_support_spec.md) — consolidates README guidance for NVIDIA, AMD, Intel, Apple Silicon, DirectML, Ascend, Cambricon, and Iluvatar devices so packages can surface the correct driver and wheel instructions.【F:README.md†L200-L315】
+
+## Installation Pathways
+- [Manual Installation Specification](docs/specs/manual_install_spec.md) — describes how to clone, configure, and run ComfyUI from source while mirroring the bundled experience.【F:README.md†L191-L315】【F:main.py†L25-L350】
+- [User Responsibilities Specification](docs/specs/user_responsibilities_spec.md) — lists the post-install tasks end users must complete regardless of distribution, such as copying model weights and running bundled updaters.【F:README.md†L174-L200】【F:main.py†L25-L350】
+
+## Frontend Delivery
+- [Frontend Delivery Specification](docs/specs/frontend_delivery_spec.md) — covers how the `comfyui-frontend-package` wheel is managed, how alternate frontends are fetched, and how the server serves static assets with feature flag negotiation.【F:requirements.txt†L1-L2】【F:app/frontend_management.py†L19-L214】【F:server.py†L175-L245】
+
+## Reference High-Level Topology
+Use this ASCII diagram and accompanying pseudocode as a starting point for new projects inspired by ComfyUI’s architecture.
+
+```
+┌────────────┐       ┌─────────────┐       ┌──────────────────┐
+│ Frontend   │◀────▶│ Prompt API  │◀────▶│ Execution Workers │
+└────────────┘   WS │ (aiohttp)   │ REST │  (local/remote)   │
+        ▲           └─────────────┘       └──────────────────┘
+        │                  ▲                       ▲
+        │                  │                       │
+        │                  │                       │
+        ▼                  │                       │
+┌────────────┐       ┌────────────┐        ┌────────────────┐
+│ Model Repo │◀────▶│ Asset Map  │◀──────▶│ Remote Adapters │
+└────────────┘       └────────────┘        └────────────────┘
+```
+
+```python
+def launch_application():
+    config = load_config_files()
+    registry = build_asset_registry(config.local_paths, config.remote_endpoints)
+    prompt_server = build_prompt_server(registry, feature_flags=config.frontend_flags)
+    worker_pool = start_execution_workers(prompt_server.queue, registry)
+    prompt_server.run(worker_pool)
+```
+
+Swap `build_execution_workers` for cloud queues or hosted inference when planning remote-first deployments, and feed the same registry into the frontend API so users can discover both local folders and API-backed models without special casing.

--- a/DESKTOP_DISTRIBUTION_SPEC.md
+++ b/DESKTOP_DISTRIBUTION_SPEC.md
@@ -1,0 +1,37 @@
+# ComfyUI Desktop Distribution Specification
+
+This document indexes the detailed specifications that describe every aspect of ComfyUI’s packaged releases. Use it as a roadmap when building or auditing desktop installers, the Windows portable bundle, or manual distribution guides.
+
+## Release Coordination
+- [Distribution Channel Specification](docs/specs/distribution_channels_spec.md) — explains how the core, desktop, and frontend repositories coordinate on a weekly cadence and how portable archives stay aligned.【F:README.md†L112-L180】【F:requirements.txt†L1-L2】
+
+## Packaged Runtime Expectations
+- [Desktop Installer Specification](docs/specs/desktop_installers_spec.md) — outlines platform targets, bundled Python requirements, directory layout, launcher behavior, and user onboarding steps for native installers.【F:README.md†L41-L199】【F:requirements.txt†L1-L30】【F:folder_paths.py†L16-L83】
+- [Windows Portable Package Specification](docs/specs/windows_portable_spec.md) — defines archive contents, update mechanisms, and shared model support for the self-contained Windows release.【F:README.md†L168-L180】【F:main.py†L297-L308】
+
+## Manual Path Reference
+- [Manual Installation Specification](docs/specs/manual_install_spec.md) — mirrors the instructions for setting up ComfyUI from source so documentation teams can produce consistent guides.【F:README.md†L191-L315】【F:requirements.txt†L1-L30】
+
+## Runtime Behavior and Frontend Delivery
+- [Runtime Initialization Specification](docs/specs/runtime_initialization.md) — captures how launchers set environment variables, register model paths, execute custom node hooks, and start the prompt queue.【F:main.py†L1-L369】
+- [Desktop Startup Sequence Specification](docs/specs/desktop_startup_sequence.md) — details the Electron app boot order from spawning `main.py` to emitting the readiness log that desktop shells watch before showing the UI.【F:requirements.txt†L1-L30】【F:main.py†L1-L369】【F:server.py†L948-L986】
+- [Frontend Delivery Specification](docs/specs/frontend_delivery_spec.md) — documents how the frontend wheel is validated, how alternate builds are fetched, and how the server exposes static assets with feature flag negotiation.【F:app/frontend_management.py†L19-L214】【F:server.py†L175-L245】
+
+## User Guidance
+- [User Responsibilities Specification](docs/specs/user_responsibilities_spec.md) — lists the post-install tasks end users must perform, regardless of whether they use an installer, portable package, or manual setup.【F:README.md†L174-L200】【F:main.py†L25-L350】
+- [Hardware Support Specification](docs/specs/hardware_support_spec.md) — aggregates accelerator-specific installation instructions to include in release notes or onboarding dialogs.【F:README.md†L200-L315】
+
+## Reference Distribution Matrix
+Use the following matrix template when planning new bundles that mix local weights with remote APIs.
+
+```markdown
+| Channel              | Python Runtime | Dependency Source      | Model Strategy              | Update Path                 |
+|----------------------|----------------|------------------------|-----------------------------|-----------------------------|
+| Windows Installer    | Embedded 3.12  | requirements.txt wheel | Precreate folders + remote  | In-app updater + releases   |
+| macOS Installer      | Embedded 3.12  | requirements.txt wheel | Prompt remote fallback      | Sparkle / auto-update feed  |
+| Windows Portable     | Embedded 3.12  | Preinstalled site-pack | Local only, user-managed    | update\update_comfyui.bat   |
+| Manual (All OS)      | System Python  | pip install -r         | User-managed + YAML remaps  | Git pull + pip upgrade      |
+| Cloud / API Hybrid   | Container 3.12 | requirements.txt wheel | Remote-first, cache locally | CI redeploy                  |
+```
+
+Extend rows to cover new operating systems or container targets, ensuring each entry points back to the detailed specification responsible for that distribution path.

--- a/docs/specs/desktop_installers_spec.md
+++ b/docs/specs/desktop_installers_spec.md
@@ -1,0 +1,66 @@
+# Desktop Installer Specification
+
+## Scope
+Defines expectations for the official ComfyUI Desktop installers published for Windows and macOS, clarifying what runtime components must be bundled and how launchers should invoke the Python backend.
+
+## Target Platforms
+- The README lists the desktop application as the primary onboarding path for both Windows and macOS users, highlighting it as the easiest option for non-technical audiences.【F:README.md†L41-L44】
+
+## Bundled Runtime Requirements
+- Installers must embed a compatible Python interpreter (3.12 or newer) and preinstall every package listed in `requirements.txt`, matching the versions that manual installers fetch via pip. This guarantees parity between installer builds and source deployments.【F:requirements.txt†L1-L30】【F:README.md†L245-L252】
+- The bundled environment should include the `comfyui-frontend-package` wheel specified in `requirements.txt` because the backend validates the installed version at startup and logs warnings when mismatched.【F:app/frontend_management.py†L1-L81】
+
+## Directory Layout
+- Installer payloads should create the canonical folder tree defined in `folder_paths.py` (`models/checkpoints`, `models/vae`, `models/loras`, etc.) plus runtime directories (`input`, `output`, `temp`, `user`) so the UI can run immediately after installation without additional setup.【F:folder_paths.py†L16-L83】
+- Extra configuration templates such as `extra_model_paths.yaml.example` may be shipped alongside the executable to help users remap model folders or share assets across UIs.【F:extra_model_paths.yaml.example†L1-L47】
+
+## Launcher Behavior
+- Native wrappers ultimately execute `python main.py` inside the bundled environment. Launchers should forward CLI flags that desktop users commonly toggle (e.g., `--auto-launch`, `--listen`, `--port`) and respect the runtime initialization sequence documented in `main.py` so progress reporting, custom node startup scripts, and prompt queue threading behave identically to manual runs.【F:main.py†L25-L350】
+- Windows installers may optionally expose `--windows-standalone-build` to trigger updater maintenance before startup, ensuring the packaged updater binaries remain current.【F:main.py†L303-L308】
+
+## Post-Install User Steps
+- After installation the only required user action is to copy model weights into the appropriate subfolders (checkpoints, VAEs, LoRAs, etc.), mirroring the manual instructions documented in the README.【F:README.md†L174-L199】
+
+## Reference Installer Blueprint
+Packaging teams can model their bundler after the following pseudocode to ensure parity with the runtime expectations while leaving room for remote model configuration.
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import installer
+
+
+def build_package(source: Path, target: Path) -> None:
+    env = installer.VirtualEnv(python="3.12.7")
+    env.install_requirements(source / "requirements.txt")
+
+    layout = {
+        "root": target,
+        "app": target / "ComfyUI",
+        "python": target / "python",
+    }
+
+    installer.copy_tree(source, layout["app"], exclude={".git", "output", "temp"})
+    installer.embed_python(env, layout["python"])
+
+    for folder in ["input", "output", "temp", "user"]:
+        (layout["app"] / folder).mkdir(parents=True, exist_ok=True)
+
+    (layout["app"] / "user" / "remote_endpoints.yaml").write_text(
+        "sdxl: https://api.example.com/v1/inference\n"
+    )
+
+    installer.create_shortcut(
+        name="ComfyUI",
+        target=layout["python"] / "python.exe",
+        arguments="main.py --auto-launch",
+        icon=source / "assets" / "icon.ico",
+    )
+
+
+build_package(Path.cwd(), Path("dist/ComfyUI-Desktop"))
+```
+
+Integrate vendor-specific GPU runtimes, notarization, or code signing within this scaffold while keeping the bundled Python and directory layout aligned with `folder_paths.py` so downstream documentation remains accurate.【F:folder_paths.py†L16-L83】【F:main.py†L25-L350】

--- a/docs/specs/desktop_startup_sequence.md
+++ b/docs/specs/desktop_startup_sequence.md
@@ -1,0 +1,89 @@
+# Desktop Startup Sequence Specification
+
+## Scope
+This reference walks through the complete launch flow used by the Electron-based ComfyUI Desktop application. It traces execution from the moment the desktop bundler starts its embedded Python runtime until the browser window renders the UI, calling out the checks that guarantee dependencies, assets, and services are ready before the interface appears.
+
+## 1. Bundler Process Bootstraps the Runtime
+- Desktop packages embed Python along with every dependency listed in `requirements.txt`, so the backend binaries are available before the Electron shell spawns the interpreter.【F:requirements.txt†L1-L30】
+- Launchers invoke the bundled interpreter with `main.py` and distribution-specific flags such as `--windows-standalone-build` and `--auto-launch`, which are defined in the shared CLI parser consumed by `comfy.options` at import time.【F:main.py†L1-L24】【F:comfy/cli_args.py†L33-L105】
+- `app.logger.setup_logger` replaces `stdout`/`stderr` with interceptors, allowing the Electron host to stream structured logs (for readiness detection or UI consoles) as soon as the process starts emitting output.【F:app/logger.py†L13-L84】
+
+### Reference Electron Launcher Skeleton
+```ts
+import { app, BrowserWindow } from 'electron';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+let backend;
+app.on('ready', () => {
+  const python = path.join(process.resourcesPath, 'python', 'python.exe');
+  backend = spawn(python, ['main.py', '--windows-standalone-build', '--auto-launch'], {
+    cwd: path.join(process.resourcesPath, 'ComfyUI'),
+    env: { ...process.env }
+  });
+
+  backend.stdout.on('data', (buf) => {
+    const text = buf.toString();
+    if (text.includes('To see the GUI go to:')) {
+      BrowserWindow.getAllWindows()[0]?.loadURL('http://127.0.0.1:8188');
+    }
+  });
+});
+```
+The watcher reacts to the readiness log generated later by the prompt server startup sequence.【F:server.py†L960-L986】
+
+## 2. CLI Parsing and Logging Guarantees
+- `comfy.options.enable_args_parsing()` primes the global argument parser before any other module imports, ensuring flags from the Electron launcher are honored consistently.【F:main.py†L1-L24】
+- `setup_logger` applies verbosity settings immediately, so warnings about missing dependencies or old interpreters surface before the UI attempts to load static assets.【F:main.py†L1-L24】【F:app/logger.py†L54-L97】
+
+## 3. Path and Dependency Validation
+- `apply_custom_paths()` loads `extra_model_paths.yaml` from the installation root plus any overrides passed on the command line, then seeds canonical subdirectories (checkpoints, VAE, LoRA, diffusion models) beneath the chosen output folder. This ensures model discovery works even before users copy weights into place.【F:main.py†L25-L57】
+- Input and user directories are remapped when flags are provided, letting installers locate shared storage or user profiles on first launch.【F:main.py†L35-L57】
+
+## 4. Custom Node Pre-Startup Execution
+- The runtime enumerates every folder registered under `custom_nodes`, running `prestartup_script.py` for each module unless the user disables or whitelists nodes. Errors are logged but do not crash startup, giving bundles a chance to report broken extensions before the UI loads them.【F:main.py†L60-L105】
+
+## 5. Device and Environment Configuration
+- Accelerator-related switches (`--default-device`, `--cuda-device`, `--oneapi-device-selector`, `--deterministic`) translate into environment variables before PyTorch is imported, guaranteeing the packaged backend honors GPU selection made in the Electron UI.【F:main.py†L117-L140】
+- Windows builds additionally set `MIMALLOC_PURGE_DELAY=0` to keep the bundled mimalloc allocator responsive for repeated launches.【F:main.py†L113-L115】
+
+## 6. Import Ordering and Safety Checks
+- The launcher warns if `torch` was imported prematurely, protecting environment tweaks performed above. It then imports the execution engine, prompt server, protocol constants, node registry, and version metadata required for the desktop app.【F:main.py†L142-L154】
+- `cuda_malloc_warning()` inspects the active GPU name against a blacklist and emits guidance about disabling async allocation when necessary, preventing UI freezes caused by unsupported hardware.【F:main.py†L156-L166】
+
+## 7. Prompt Execution Thread and Progress Hooks
+- `prompt_worker` starts in a daemon thread to process queued workflows without blocking the event loop. It selects cache policies based on CLI flags, reports execution time, manages garbage collection, and relays success or error states back to the server queue.【F:main.py†L168-L235】
+- `hijack_progress()` installs a global hook so node-level progress and preview images stream to connected clients via websocket events, satisfying the desktop UI’s live feedback requirements.【F:main.py†L237-L275】
+
+## 8. Temporary Workspace and Database Preparation
+- `cleanup_temp()` clears the temp directory each launch, while `setup_database()` initialises optional SQL features when dependencies from the bundled environment are available. Failures become startup warnings instead of hard crashes, allowing the UI to appear with actionable guidance.【F:main.py†L277-L289】
+
+## 9. Prompt Server Construction
+- `start_comfyui()` optionally applies a custom temp directory, runs the Windows updater hook, creates the asyncio event loop, and instantiates `PromptServer` with that loop.【F:main.py†L292-L314】
+- The server constructor wires middleware, enforces upload limits, initialises user/model/custom-node managers, and picks the frontend root by calling `FrontendManager.init_frontend`, which validates the installed `comfyui-frontend-package` wheel or downloads an alternate build requested via CLI.【F:server.py†L162-L205】【F:app/frontend_management.py†L200-L360】
+- `PromptServer.setup()` creates a long-lived `aiohttp` client session used by certain routes before any connections arrive.【F:server.py†L781-L789】
+
+## 10. Route Registration and Static Asset Exposure
+- `PromptServer.add_routes()` registers REST endpoints for embeddings, models, file uploads, workflow templates, extension assets, and embedded docs before finally serving `index.html` from the resolved web root. This guarantees that by the time the Electron window navigates to the backend URL, all required assets and APIs are available.【F:server.py†L248-L360】
+- Custom node web extensions and optional documentation packages are automatically mounted if present in the bundled site-packages, matching the dependencies declared in `requirements.txt`.【F:server.py†L228-L314】【F:requirements.txt†L1-L23】
+
+## 11. Launch Signal and UI Display
+- After route registration, `start_comfyui()` launches the prompt worker thread, ensures the temp directory exists, and registers an optional `call_on_start` callback when `--auto-launch` is active. Desktop bundles can reuse this callback to open a browser or notify the Electron renderer when the service becomes reachable.【F:main.py†L328-L347】
+- `run()` concurrently awaits `PromptServer.start_multi_address()` and the websocket publish loop. Once listening sockets bind successfully, the server logs `To see the GUI go to: …` and executes `call_on_start`, providing the scheme, address, and port that the Electron shell should load.【F:main.py†L237-L350】【F:server.py†L948-L986】
+- The top-level `__main__` block logs interpreter and ComfyUI versions, prints any queued startup warnings (such as outdated frontend packages), and finally blocks the event loop until shutdown, keeping the UI responsive while background workers handle prompts.【F:main.py†L353-L369】【F:app/logger.py†L90-L97】
+
+## 12. Recommended Renderer Readiness Flow
+Desktop builds can coordinate their renderer process with the backend readiness signal using the following pattern:
+
+```ts
+backend.stdout.on('data', (buf) => {
+  const text = buf.toString();
+  if (text.includes('To see the GUI go to:')) {
+    const url = text.split('To see the GUI go to:')[1].trim();
+    mainWindow.webContents.send('backend-ready', url);
+    if (!mainWindow.isVisible()) mainWindow.show();
+  }
+});
+```
+
+The renderer listens for the `backend-ready` IPC event, displays a loading indicator until it fires, and only then embeds the ComfyUI frontend, guaranteeing all dependencies, routes, and websockets negotiated during startup are in place.【F:server.py†L962-L986】【F:main.py†L333-L365】

--- a/docs/specs/distribution_channels_spec.md
+++ b/docs/specs/distribution_channels_spec.md
@@ -1,0 +1,61 @@
+# Distribution Channel Specification
+
+## Scope
+Explains how ComfyUI coordinates releases across core, desktop, and frontend repositories so packaging teams know when to trigger installer builds and how to keep components in sync.
+
+## Weekly Cadence and Tagging
+- The README documents a weekly release target (typically Friday) subject to change for major features or model drops. Core releases are tagged in this repository and act as the reference point for downstream packaging.【F:README.md†L112-L118】
+
+## Desktop Repository Responsibilities
+- The dedicated ComfyUI Desktop repository consumes the latest core tag and produces platform-specific installers. It also embeds a complete Python runtime plus dependencies so end users only supply model files after installation.【F:README.md†L120-L126】【F:README.md†L41-L47】
+
+## Frontend Coordination
+- The standalone frontend repository merges weekly UI updates back into core ahead of each release while continuing development for the next cycle. Desktop bundles must capture the frontend version locked in `requirements.txt` for the tagged release to avoid mismatches.【F:README.md†L123-L126】【F:requirements.txt†L1-L2】
+
+## Portable Archive Alignment
+- The Windows portable archive ships from the same release train as the installers. Because it bundles Python and dependencies, it stays compatible with the tagged frontend and only requires users to extract and launch the packaged runner.【F:README.md†L168-L180】
+
+## Manual Installation as Reference
+- Manual installation instructions mirror the bundled dependency set, ensuring that testing a release from source (`pip install -r requirements.txt; python main.py`) reproduces the exact runtime that installers ship. Packaging teams can use manual install smoke tests as a baseline for verifying release quality.【F:README.md†L191-L252】
+
+## Reference Release Workflow
+The following GitHub Actions outline keeps desktop installers, portable archives, and documentation synchronized around each tag.
+
+```yaml
+name: release-train
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install -r requirements.txt
+      - run: pytest
+      - uses: actions/upload-artifact@v4
+        with:
+          name: comfyui-core-wheel
+          path: dist/*.whl
+
+  build-desktop:
+    needs: build-core
+    uses: comfyui/desktop/.github/workflows/build.yml@main
+    with:
+      core-wheel: ${{ needs.build-core.outputs.core-wheel }}
+
+  build-portable:
+    needs: build-core
+    uses: comfyui/desktop/.github/workflows/portable.yml@main
+
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: mkdocs gh-deploy --force
+```
+
+Mirroring the weekly cadence documented in the README, this workflow ensures every tagged release drives automated builds for installers and the portable archive while running regression tests against the shared dependency manifest.【F:README.md†L112-L180】【F:requirements.txt†L1-L30】 Adapt the reusable workflows to inject platform-specific steps (e.g., notarizing macOS builds) without diverging from the synchronized release process.

--- a/docs/specs/frontend_delivery_spec.md
+++ b/docs/specs/frontend_delivery_spec.md
@@ -1,0 +1,59 @@
+# Frontend Delivery Specification
+
+## Scope
+Describes how ComfyUI packages, validates, and serves its web frontend so desktop bundles, portable archives, and manual installs stay synchronized with backend releases.
+
+## Packaging Strategy
+- The compiled frontend is published as the `comfyui-frontend-package` wheel and pinned in `requirements.txt`, ensuring every distribution installs an identical UI build for a given release.【F:requirements.txt†L1-L2】
+
+## Version Enforcement
+- At startup `FrontendManager.check_frontend_version()` reads the installed wheel version, compares it to the required version from `requirements.txt`, and logs a structured warning if the runtime is behind, including remediation instructions for missing wheels. Bundled runtimes must therefore ship the correct wheel to avoid first-run warnings.【F:app/frontend_management.py†L19-L81】
+
+## Alternate Frontend Sources
+- `FrontendManager` supports specifying `--front-end-version` in the form `owner/repo@tag`, fetching `dist.zip` assets from GitHub releases (stable or prerelease) when requested. This enables installers to prebundle custom frontends while still allowing advanced users to switch builds at runtime.【F:app/frontend_management.py†L82-L170】
+- The manager extracts downloaded zips into `web_custom_versions`, making them discoverable without modifying the packaged assets. Desktop builds can pre-populate this directory with curated alternatives if desired.【F:app/frontend_management.py†L171-L214】
+
+## Server Integration
+- `PromptServer` chooses between the installed frontend root and any custom override supplied by `--front-end-root`, logging the final path so operators can confirm which UI is being served. Static assets are then delivered via the `/` route with cache disabled to ensure hot updates reach the browser immediately.【F:server.py†L175-L245】
+
+## Feature Flag Negotiation
+- Websocket clients send their supported feature flags on the first message; the server records them and replies with server-side capabilities. Frontend releases rely on this negotiation to opt into features like preview metadata without breaking older builds.【F:server.py†L188-L236】
+
+## Reference Frontend Sync Script
+Operators who fork the UI can automate wheel promotion and backend validation with the following Python utility.
+
+```python
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO = "org/custom-frontend"
+TAG = "v1.2.3"
+
+
+def download_frontend(dist_dir: Path) -> Path:
+    asset = f"https://github.com/{REPO}/releases/download/{TAG}/dist.zip"
+    archive = dist_dir / "dist.zip"
+    archive.write_bytes(subprocess.check_output(["curl", "-L", asset]))
+    subprocess.run(["unzip", "-o", str(archive), "-d", str(dist_dir)], check=True)
+    return dist_dir / "dist"
+
+
+def install_frontend(frontend_root: Path) -> None:
+    subprocess.run([
+        "python", "-m", "pip", "install", "comfyui-frontend-package==1.*", "--upgrade"
+    ], check=True)
+    custom_root = Path("web_custom_versions") / TAG
+    if custom_root.exists():
+        subprocess.run(["rm", "-rf", str(custom_root)])
+    subprocess.run(["cp", "-R", str(frontend_root), str(custom_root)], check=True)
+
+
+if __name__ == "__main__":
+    dist_dir = Path("build")
+    dist_dir.mkdir(exist_ok=True)
+    install_frontend(download_frontend(dist_dir))
+```
+
+Desktop bundles can call this during CI to stage alternates inside `web_custom_versions` while still relying on the pinned wheel as the default experience, aligning with `FrontendManager`’s discovery logic.【F:app/frontend_management.py†L82-L214】

--- a/docs/specs/hardware_support_spec.md
+++ b/docs/specs/hardware_support_spec.md
@@ -1,0 +1,70 @@
+# Hardware Support Specification
+
+## Scope
+Summarizes the officially documented procedures for configuring ComfyUI across different accelerator vendors so packaging teams can surface the right guidance during installation.
+
+## NVIDIA GPUs
+- Users install CUDA-enabled PyTorch via `pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu129`, with optional nightly wheels for early adopters. Troubleshooting steps advise reinstalling torch when CUDA support is missing.【F:README.md†L227-L244】
+
+## AMD GPUs
+- Linux users install ROCm 6.4 wheels (stable or nightly) before launching ComfyUI. Additional environment variables such as `HSA_OVERRIDE_GFX_VERSION` target unsupported RDNA2/RDNA3 cards, while `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL` and `PYTORCH_TUNABLEOP_ENABLED` can unlock optimizations.【F:README.md†L200-L315】
+
+## Intel GPUs
+- Intel Arc users install PyTorch XPU wheels from the dedicated index URL, with guidance to consult Intel’s documentation. Optionally they can leverage Intel Extension for PyTorch for further optimizations.【F:README.md†L221-L226】
+
+## Apple Silicon
+- Apple Silicon instructions direct users to install nightly Metal-enabled PyTorch builds from Apple’s guide before following the general manual installation steps and copying models into the appropriate directories.【F:README.md†L255-L264】
+
+## DirectML Fallback
+- AMD cards on Windows without ROCm support can use `pip install torch-directml` and launch ComfyUI with `--directml`, though the README labels this path as poorly supported and recommends ROCm when available.【F:README.md†L266-L271】
+
+## Ascend, Cambricon, and Iluvatar Accelerators
+- Each vendor requires installing its toolkit and PyTorch extension (torch-npu, torch_mlu, or Iluvatar Corex Toolkit) before running `python main.py`. The README links to vendor-specific installation guides to ensure users meet prerequisites.【F:README.md†L272-L295】
+
+## Reference Device Negotiation Helper
+Bundle launchers can detect accelerator availability and select the appropriate CLI flags before invoking `main.py` by using a helper like the following.
+
+```python
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+
+def detect_accelerator() -> str:
+    if shutil.which("nvidia-smi"):
+        return "cuda"
+    if shutil.which("rocminfo"):
+        return "rocm"
+    if shutil.which("intel_gpu_top"):
+        return "xpu"
+    if os.name == "posix" and subprocess.call(["sysctl", "machdep.cpu.brand_string"], stdout=subprocess.DEVNULL) == 0:
+        return "metal"
+    if shutil.which("dml_diag"):
+        return "directml"
+    return "cpu"
+
+
+def build_launch_command() -> list[str]:
+    accelerator = detect_accelerator()
+    match accelerator:
+        case "cuda":
+            return ["python", "main.py"]
+        case "rocm":
+            return ["python", "main.py", "--hip"]
+        case "xpu":
+            return ["python", "main.py", "--use-xpu"]
+        case "metal":
+            return ["python", "main.py", "--use-metal"]
+        case "directml":
+            return ["python", "main.py", "--directml"]
+        case _:
+            return ["python", "main.py", "--cpu"]
+
+
+if __name__ == "__main__":
+    print("Launching:", " ".join(build_launch_command()))
+```
+
+Mapping detections to the documented CLI switches keeps end-user experiences consistent with the README guidance while allowing distributors to plug in remote inference fallbacks when no supported accelerator is present.【F:README.md†L200-L315】

--- a/docs/specs/manual_install_spec.md
+++ b/docs/specs/manual_install_spec.md
@@ -1,0 +1,63 @@
+# Manual Installation Specification
+
+## Scope
+Provides a step-by-step reference for packaging and documentation teams to describe manual ComfyUI installations that mirror the bundled desktop experience across Windows, Linux, and macOS.
+
+## Prerequisites
+- Users install Python 3.13 (or 3.12 for compatibility) prior to cloning the repository, matching the interpreter versions embedded in official installers.【F:README.md†L191-L199】
+- Hardware-specific PyTorch wheels must be installed before running ComfyUI: ROCm for AMD, XPU/IPEX for Intel GPUs, CUDA 12.9 wheels for NVIDIA, DirectML for unsupported AMD GPUs on Windows, and vendor packages for Ascend, Cambricon, or Iluvatar accelerators.【F:README.md†L193-L295】
+
+## Repository Setup
+1. Clone `https://github.com/comfyanonymous/ComfyUI`.
+2. Populate the `models` directory with checkpoints (`models/checkpoints`) and VAEs (`models/vae`) alongside any other assets the workflow requires.【F:README.md†L197-L200】
+3. Optionally copy `extra_model_paths.yaml.example` to `extra_model_paths.yaml` and adjust paths to point at shared model storage.【F:extra_model_paths.yaml.example†L1-L47】
+
+## Dependency Installation
+- Execute `pip install -r requirements.txt` inside the repository to install all required runtime packages, mirroring the versions shipped in installers.【F:README.md†L245-L252】【F:requirements.txt†L1-L30】
+
+## Launching
+- Run `python main.py` from the repository root. Environment variables documented in the README (e.g., `HSA_OVERRIDE_GFX_VERSION`, `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL`, `PYTORCH_TUNABLEOP_ENABLED`) can be set to fine-tune AMD performance or compatibility.【F:README.md†L296-L315】
+- The runtime initialization sequence handles model path overrides, custom node scripts, device selection, and prompt queue setup exactly as described in the Runtime Initialization Specification, so manual installs behave the same as bundled ones.【F:main.py†L25-L350】
+
+## Reference Bootstrap Script
+Documentation teams can ship a cross-platform installer helper that codifies the manual steps for both local and remote model scenarios.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+"$PYTHON_BIN" -m venv .venv
+source .venv/bin/activate
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+python - <<'PY'
+from pathlib import Path
+import yaml
+
+base = Path.cwd()
+model_layout = {
+    "checkpoints": [base / "models" / "checkpoints"],
+    "vae": [base / "models" / "vae"],
+    "loras": [base / "models" / "loras"],
+    "remote": {"sdxl": "https://api.example.com/v1/inference"},
+}
+
+for kind, paths in model_layout.items():
+    if isinstance(paths, dict):
+        continue
+    for path in paths:
+        path.mkdir(parents=True, exist_ok=True)
+
+extra = base / "extra_model_paths.yaml"
+if not extra.exists():
+    yaml.safe_dump({"checkpoints": [str(model_layout["checkpoints"][0])]}, extra.open("w"))
+PY
+
+echo "Run '. .venv/bin/activate && python main.py --auto-launch' to start ComfyUI"
+```
+
+This helper mirrors the README instructions while seeding a remote-model placeholder entry that downstream installers can update for hosted inference endpoints, ensuring parity between manual setups and desktop bundles.【F:README.md†L191-L315】

--- a/docs/specs/model_asset_management.md
+++ b/docs/specs/model_asset_management.md
@@ -1,0 +1,65 @@
+# Model and Asset Management Specification
+
+## Scope
+Clarifies how ComfyUI discovers, categorizes, and persists model assets across bundled and manual installations. This specification supports packaging teams that must pre-create directory structures or customize search paths.
+
+## Default Directory Map
+- `folder_paths` anchors all model directories relative to the installation base (overridden by `--base-directory`), automatically wiring `models/checkpoints`, `models/vae`, `models/loras`, `models/diffusion_models`, ControlNet/T2I adapters, embeddings, hypernetworks, upscale models, and more.【F:folder_paths.py†L1-L44】【F:folder_paths.py†L49-L66】
+- Custom node discovery defaults to `<install>/custom_nodes`, while runtime directories such as `output`, `temp`, `input`, and `user` live beside the codebase. Installers must ship these directories or create them at first launch to avoid permission issues.【F:folder_paths.py†L33-L55】【F:folder_paths.py†L68-L83】
+
+## Dynamic Directory Overrides
+- `folder_paths` exposes `set_output_directory`, `set_input_directory`, `set_temp_directory`, and `set_user_directory` so CLI flags can point to alternate storage locations (e.g., external drives in portable builds). These setters update the global registry consumed by upload handlers and save nodes.【F:folder_paths.py†L86-L119】
+- `main.py` automatically adds save destinations for checkpoints, CLIP, VAE, diffusion models, and LoRAs under the active output directory, ensuring generated assets never pollute the read-only install area shipped inside installers.【F:main.py†L35-L47】
+
+## Extra Model Paths Configuration
+- Optional `extra_model_paths.yaml` files merge into the same directory map at startup. The sample configuration demonstrates per-UI base paths, multi-line folder lists (for diffusion models and LoRAs), and custom node directories, enabling shared model pools across different products.【F:main.py†L25-L34】【F:extra_model_paths.yaml.example†L1-L47】
+
+## File Enumeration and Caching
+- `folder_paths` maintains a `filename_list_cache` and exposes helpers like `filter_files_content_types` to efficiently serve lists of models, images, videos, or audio through the HTTP API, minimizing redundant filesystem scans in large deployments.【F:folder_paths.py†L57-L83】【F:folder_paths.py†L121-L170】
+
+## Annotated Filepaths
+- `annotated_filepath` and `get_annotated_filepath` interpret suffixes like `[output]` or `[input]` to resolve resource references back to the correct directory, which is essential when workflows embed relative paths inside generated images or metadata.【F:folder_paths.py†L172-L214】
+
+## Temp Directory Hygiene
+- Startup purges the active temp directory and recreates it before the server runs, preventing stale intermediates from leaking between sessions in portable bundles that may live on removable drives.【F:main.py†L277-L334】
+
+## Reference Asset Registry Helper
+Projects that blend local folders, shared storage, and hosted checkpoints can adapt the pattern below to stay aligned with ComfyUI’s lookup rules.
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+@dataclass
+class AssetRegistry:
+    root: Path
+    folders: Mapping[str, Iterable[Path]]
+    remotes: Mapping[str, str]  # model kind -> API endpoint
+    cache_root: Path
+    _resolved: dict[str, list[Path]] = field(default_factory=dict)
+
+    def initialise(self) -> None:
+        for kind, locations in self.folders.items():
+            self._resolved[kind] = [self._resolve_path(path) for path in locations]
+        for kind, endpoint in self.remotes.items():
+            adapter = build_remote_adapter(kind, endpoint)
+            cached_path = adapter.cache_into(self.cache_root / kind)
+            self._resolved.setdefault(kind, []).append(cached_path)
+
+    def iter_kind(self, kind: str) -> Iterable[Path]:
+        yield from self._resolved.get(kind, [])
+
+    def _resolve_path(self, path: Path) -> Path:
+        return path if path.is_absolute() else (self.root / path)
+
+
+def build_remote_adapter(kind: str, endpoint: str):
+    # Provide thin wrappers for hosted checkpoints (REST, S3, Hugging Face Hub, etc.).
+    ...
+```
+
+This mirrors how `folder_paths.py` pre-populates canonical directories and merges `extra_model_paths.yaml` entries at launch.【F:folder_paths.py†L16-L83】【F:main.py†L25-L57】 Remote adapters let you expose API-backed weights alongside local files with identical node semantics, making the specification reusable for hybrid deployments.【F:folder_paths.py†L135-L214】

--- a/docs/specs/prompt_server_spec.md
+++ b/docs/specs/prompt_server_spec.md
@@ -1,0 +1,106 @@
+# Prompt Server Specification
+
+## Scope
+Defines the responsibilities of `server.py` and the `PromptServer` class that wraps aiohttp for all ComfyUI distributions. It explains middleware, websocket lifecycle, REST endpoints, queue coordination, and frontend delivery expectations that installers must satisfy.
+
+## Core Initialization
+- `PromptServer` wires together user, model, and custom node managers, exposes internal API routes, and instantiates the shared `PromptQueue` that orchestrates workflow execution.【F:server.py†L143-L157】
+- The aiohttp application enforces maximum upload sizes using `--max-upload-size` and attaches cache-control plus optional compression and CORS middleware so packaged frontends experience consistent HTTP behavior.【F:server.py†L162-L176】【F:server.py†L171-L172】
+- Frontend assets resolve through `FrontendManager.init_frontend`, allowing bundles to pin specific frontend wheels or serve custom roots via `--front-end-root`. The resolved path is logged to simplify debugging custom distributions.【F:server.py†L175-L181】
+
+## Middleware Strategy
+- `cache_control` headers prevent browsers from caching frequently changing JSON responses, while `compress_body` negotiates gzip for JSON/text payloads when clients support it. This keeps websocket and REST payloads lean on slower networks.【F:server.py†L42-L61】
+- When no explicit CORS origin is configured, `create_origin_only_middleware` rejects requests where the Host and Origin differ on loopback interfaces, guarding local installs against CSRF-style queue injections from malicious web pages.【F:server.py†L107-L140】
+
+## Websocket Lifecycle
+- The `/ws` route provisions a websocket per client, reuses session identifiers across reconnects, and immediately sends queue status plus the actively executing node when applicable. Feature-flag negotiation occurs on the first message to tailor server responses (e.g., preview metadata) to each client.【F:server.py†L188-L236】
+- Socket references and negotiated capabilities are stored separately so prompt progress hooks in `main.py` can address the correct connection when broadcasting updates.【F:server.py†L188-L205】【F:server.py†L226-L236】
+
+## HTTP API Surface
+- `GET /` streams the packaged `index.html` with no-cache headers, ensuring desktop builds always load the bundled frontend version.【F:server.py†L238-L245】
+- Model discovery endpoints (`/models`, `/models/{folder}`, `/embeddings`) read from `folder_paths` so any path overrides applied during startup automatically flow to the UI. A dedicated `/extensions` route returns discovered frontend extensions from both the shipped web root and registered custom node directories.【F:server.py†L247-L286】
+- Upload handlers normalize writes into the appropriate `input`, `output`, or `temp` directories while preventing directory traversal. Optional hash comparison avoids duplicating identical uploads, mirroring the expectations of portable deployments where disk space is limited.【F:server.py†L288-L371】
+
+## Prompt Queue Integration
+- `PromptServer` exposes `prompt_queue`, which the worker thread created in `main.py` consumes. REST and websocket handlers enqueue prompts, while queue state is reflected back through `send`/`send_sync` events so the UI can display live status.【F:server.py†L143-L157】【F:main.py†L168-L234】
+
+## Publishing and Multi-Address Support
+- `run()` coordinates simultaneous binding to multiple comma-separated listen addresses and starts the publish loop that drains queued websocket notifications, supporting installers that expose ComfyUI on IPv4 and IPv6 simultaneously.【F:main.py†L237-L243】
+
+## Frontend Package Overrides
+- `FrontendManager` can fetch alternate frontend builds from GitHub releases when operators specify `--front-end-version`. Bundled runtimes may preseed custom versions, but they must still keep the CLI hooks accessible for advanced users.【F:server.py†L175-L181】【F:app/frontend_management.py†L1-L120】
+
+## TLS and Client Session Reuse
+- The server maintains an aiohttp client session for outbound requests (e.g., fetching remote custom nodes) and respects TLS settings provided at launch, allowing desktop builds to bundle certificates or reuse system ones without modification.【F:server.py†L143-L160】
+
+## Reference Service Blueprint
+The snippet below turns these behaviours into a portable template suitable for projects that orchestrate local and remote inference endpoints.
+
+```python
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Callable
+
+from aiohttp import web
+
+
+@dataclass
+class PromptJob:
+    id: str
+    graph: dict[str, Any]
+    assets: dict[str, Any]
+
+
+class PromptGateway:
+    def __init__(self, execute: Callable[[PromptJob], AsyncIterator[dict[str, Any]]]):
+        self._execute = execute
+        self._queue: asyncio.Queue[PromptJob] = asyncio.Queue()
+        self._subscribers: set[Callable[[str, dict[str, Any]], Any]] = set()
+
+    async def submit(self, job: PromptJob) -> str:
+        await self._queue.put(job)
+        return job.id
+
+    def subscribe(self, callback: Callable[[str, dict[str, Any]], Any]) -> None:
+        self._subscribers.add(callback)
+
+    async def worker_loop(self) -> None:
+        while True:
+            job = await self._queue.get()
+            async for update in self._execute(job):
+                await self.broadcast(job.id, update)
+
+    async def broadcast(self, job_id: str, payload: dict[str, Any]) -> None:
+        for callback in list(self._subscribers):
+            callback(job_id, payload)
+
+
+async def create_app(gateway: PromptGateway) -> web.Application:
+    app = web.Application()
+    app["gateway"] = gateway
+
+    async def submit_handler(request: web.Request) -> web.Response:
+        body = await request.json()
+        job = PromptJob(**body)
+        job_id = await gateway.submit(job)
+        return web.json_response({"id": job_id})
+
+    app.router.add_post("/api/prompts", submit_handler)
+    # Add websocket handler mirroring ComfyUI's `prompt_socket_handler`.
+    return app
+
+
+def start_prompt_server(execute_fn: Callable[[PromptJob], AsyncIterator[dict[str, Any]]]) -> None:
+    gateway = PromptGateway(execute_fn)
+    loop = asyncio.get_event_loop()
+    loop.create_task(gateway.worker_loop())
+    web.run_app(loop.run_until_complete(create_app(gateway)))
+```
+
+Design cues:
+
+- **Async iterators** let `execute_fn` stream preview updates from either local GPU inference or hosted APIs, matching ComfyUI’s websocket cadence.【F:server.py†L188-L236】
+- The pub/sub registry in `PromptGateway.broadcast` echoes how ComfyUI fans notifications to every websocket session, which is vital when multiple clients collaborate on the same queue.【F:server.py†L126-L173】
+- Keeping the HTTP endpoint names aligned with ComfyUI simplifies frontend reuse: an installer can swap in a different backend while leaving the shipped web client untouched.

--- a/docs/specs/python_environment_spec.md
+++ b/docs/specs/python_environment_spec.md
@@ -1,0 +1,62 @@
+# Python Environment and Dependency Specification
+
+## Scope
+Outlines the Python runtime expectations for ComfyUI across manual installs, portable bundles, and desktop installers, highlighting how dependencies are versioned and how users tailor accelerator libraries per platform.
+
+## Supported Python Versions
+- The launcher warns when running under Python 3.9 or 3.10 but recommends 3.12+, with explicit messaging when it detects interpreters older than 3.10. Desktop bundles therefore embed Python 3.12 or newer to avoid the warning path.【F:main.py†L353-L360】
+- Manual installation guidance states that Python 3.13 is fully supported while 3.12 remains an alternative for compatibility with older custom nodes.【F:README.md†L191-L199】
+
+## Dependency Manifest
+- `requirements.txt` pins the shipped frontend (`comfyui-frontend-package`), workflow templates, embedded docs, and core libraries including PyTorch, torchvision, torchaudio, transformers, safetensors, aiohttp, SQLAlchemy, and optional extras such as kornia and spandrel.【F:requirements.txt†L1-L30】
+- Bundled runtimes mirror this manifest so end users never have to resolve Python packages manually; manual installers execute `pip install -r requirements.txt` to match the bundled environment.【F:README.md†L245-L252】
+
+## Frontend Package Enforcement
+- At startup the backend checks that the installed `comfyui-frontend-package` version matches the requirement file and surfaces warnings when the wheel is missing or outdated, ensuring desktop bundles ship the correct web UI snapshot.【F:app/frontend_management.py†L1-L81】
+
+## Accelerator-Specific Guidance
+- Windows, Linux, and macOS users follow vendor-specific PyTorch install commands: ROCm 6.4 wheels for AMD, XPU/IPEX binaries for Intel, CUDA 12.9 wheels for NVIDIA, and torch-directml for DirectML fallback. Each command is documented so manual setups or custom bundles can substitute the appropriate wheel before launching the UI.【F:README.md†L193-L270】
+- Additional sections cover Ascend NPUs, Cambricon MLUs, and Iluvatar accelerators, directing users to vendor documentation before running `python main.py`. Bundled distributions can reference these notes when providing platform-specific installers.【F:README.md†L272-L295】
+
+## Runtime Launch Commands
+- Regardless of distribution, users ultimately run `python main.py` (or a wrapper) after installing dependencies. Environment variables like `HSA_OVERRIDE_GFX_VERSION` and `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL` provide optional tuning knobs for AMD GPUs, which installers may expose through helper scripts.【F:README.md†L296-L315】
+
+## Reference Environment Verifier
+Bundle creators can embed an environment probe similar to the following to guarantee consistency before launching the UI.
+
+```python
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+REQUIRED_MODULES = {
+    "torch": "2.5.1",
+    "torchvision": "0.20.1",
+    "torchaudio": "2.5.1",
+    "aiohttp": "3.10.8",
+    "sqlalchemy": "2.0.36",
+    "comfyui-frontend-package": "1.*",
+}
+
+
+def verify_environment() -> None:
+    if sys.version_info < (3, 12):
+        raise RuntimeError("Desktop bundles should embed Python 3.12 or newer")
+
+    for module_name, expected_version in REQUIRED_MODULES.items():
+        module = importlib.import_module(module_name.replace("-", "_"))
+        assert module.__version__.startswith(expected_version.rstrip("*")), (
+            f"{module_name} {module.__version__} does not match {expected_version}"
+        )
+
+    if not Path("models/checkpoints").exists():
+        Path("models/checkpoints").mkdir(parents=True, exist_ok=True)
+
+
+if __name__ == "__main__":
+    verify_environment()
+```
+
+Extend `REQUIRED_MODULES` with accelerator-specific packages (e.g., `torch-directml`, ROCm wheels) depending on the target OS. For hosted-model deployments, add optional checks for REST client libraries or gRPC stubs before handing prompts to remote services, keeping parity with the local dependency graph.【F:README.md†L193-L315】

--- a/docs/specs/runtime_initialization.md
+++ b/docs/specs/runtime_initialization.md
@@ -1,0 +1,97 @@
+# Runtime Initialization Specification
+
+## Scope
+This document details how `main.py` prepares the ComfyUI runtime before the server loop starts. It covers CLI parsing, environment configuration, path remapping, custom-node bootstrapping, and loop orchestration so distribution teams can reproduce the exact startup behavior in bundled runtimes.
+
+## Argument Parsing and Logger Setup
+- ComfyUI enables CLI argument parsing immediately via `comfy.options.enable_args_parsing()` so every launch honours the shared parser defined under `comfy/cli_args.py`.
+- `setup_logger` applies verbosity and stdout redirection flags before any other modules emit logs, ensuring uniform logging whether the app is launched by a bundled executable or a manual `python main.py` run.【F:main.py†L1-L24】
+
+## Environment Guards for Desktop Builds
+- When the entrypoint is executed directly, ComfyUI disables Hugging Face telemetry to keep offline packages compliant with privacy-sensitive distribution channels.【F:main.py†L18-L21】
+- Windows builds set `MIMALLOC_PURGE_DELAY=0` so the bundled mimalloc allocator releases memory promptly, matching expectations of portable archives that start and stop frequently.【F:main.py†L107-L115】
+
+## Model Path Resolution
+- `apply_custom_paths()` loads `extra_model_paths.yaml` from the installation root and any additional YAML files passed through `--extra-model-paths-config`, merging them into the central `folder_paths` registry that the rest of the runtime consumes.【F:main.py†L25-L34】
+- Output, input, and user directories are overridden when `--output-directory`, `--input-directory`, or `--user-directory` are provided. The helper also auto-registers checkpoint, CLIP, VAE, diffusion model, and LoRA subfolders beneath the active output directory so save nodes can write assets without extra configuration.【F:main.py†L35-L57】
+
+## Custom Node Pre-Startup Hooks
+- Before heavy imports, bundled builds iterate every directory returned by `folder_paths.get_folder_paths("custom_nodes")` and execute `prestartup_script.py` modules unless the user disables them via `--disable-all-custom-nodes`. Execution times are logged, allowing desktop packages to surface failures that would otherwise be silent.【F:main.py†L60-L104】
+
+## Device Selection Policy
+- Command-line switches populate accelerator-specific environment variables prior to importing PyTorch. `--default-device` rewrites CUDA and HIP visible device lists to move the preferred GPU to the front. `--cuda-device` pins execution to a single index, while `--oneapi-device-selector` selects Intel GPUs. Deterministic mode enforces `CUBLAS_WORKSPACE_CONFIG` before torch loads so behavior is reproducible across restarts.【F:main.py†L117-L140】
+
+## Module Import Ordering
+- The launcher validates that `torch` has not been imported yet (issuing a warning if it has) to prevent environment variables from being ignored. It then loads the execution engine, prompt server, protocol constants, node registry, and version metadata in a controlled order so side effects—like model manager initialization—see the finalized directory layout.【F:main.py†L142-L154】
+
+## Prompt Execution Thread
+- `prompt_worker` runs in a dedicated daemon thread. It selects an execution cache policy from CLI flags, executes queued prompts, and coordinates garbage collection, model unloading, and progress reporting back to the server. Bundled runtimes rely on this worker to keep UI interactions responsive even under long-running graph executions.【F:main.py†L156-L234】
+
+## Progress Hook Integration
+- `hijack_progress()` installs a global callback that forwards node-level progress (including preview images) to the active websocket client while also updating shared execution state. This hook is registered before the server loop starts so every distribution reports consistent status updates.【F:main.py†L237-L275】
+
+## Temporary and Database Preparation
+- `cleanup_temp()` purges the temp directory on each launch to avoid leaking intermediate files across portable sessions.【F:main.py†L277-L280】
+- `setup_database()` lazily initializes optional SQL-backed features when dependencies are available, logging actionable errors if bundled runtimes omit required modules.【F:main.py†L283-L289】
+
+## Windows Updater Bridge
+- Windows standalone builds call into `new_updater.update_windows_updater()` when `--windows-standalone-build` is present, allowing the shipped updater binaries to refresh themselves before the UI starts.【F:main.py†L297-L308】
+
+## Event Loop and Auto-Launch
+- `start_comfyui()` optionally adopts an externally supplied asyncio loop, constructs the `PromptServer`, initialises extra nodes (both custom and API), re-applies saved function hooks, and wires the prompt queue thread before returning the coroutine that starts listening on the configured addresses.【F:main.py†L292-L350】
+- When `--auto-launch` is set, desktop builds open the system browser against the resolved host/port combination as soon as the server reports readiness, normalizing the first-run experience across installers.【F:main.py†L333-L347】
+
+## Runtime Version Reporting and Shutdown
+- On direct execution the launcher logs the Python interpreter version and the packaged ComfyUI version, warns when running under Python <3.10, and then runs the event loop until interruption. Cleanup always removes the temp directory—even on Ctrl+C—so repeated launches remain deterministic.【F:main.py†L353-L369】
+
+## Reference Bootstrap Template
+The following snippet distills the startup sequence into a reusable helper for other AI runtimes that need to juggle local folders and remote APIs. It mirrors the behaviours above while exposing hooks you can adapt for alternate dependency graphs.
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+@dataclass
+class RuntimeConfig:
+    root: Path
+    models: Mapping[str, Iterable[Path]]  # e.g. {"checkpoints": [Path("/mnt/models")]}
+    remote_models: Mapping[str, str]      # name -> REST or gRPC endpoint
+    temp_dir: Path
+    log_level: str = "INFO"
+    auto_launch: bool = False
+
+
+def bootstrap_runtime(config: RuntimeConfig) -> None:
+    """Prepare directories, environment variables, and execution threads."""
+    enable_cli_parser()
+    configure_logging(config.log_level)
+    disable_vendor_telemetry()
+
+    register_model_paths(config.root, config.models)
+    register_remote_providers(config.remote_models)
+    prepare_runtime_directories(config.root, config.temp_dir)
+    execute_custom_prelaunch_scripts(config.root / "custom_nodes")
+
+    selected_device = resolve_device_from_cli()
+    configure_accelerator_env(selected_device)
+
+    start_prompt_worker_thread(cache_policy=read_cache_policy())
+    attach_progress_hooks()
+    cleanup_temp_on_exit(config.temp_dir)
+
+    loop = get_or_create_event_loop()
+    server = build_prompt_server(loop=loop)
+    if config.auto_launch:
+        schedule_browser_launch(server.listen_host, server.listen_port)
+    loop.run_until_complete(server.start())
+```
+
+Key extension points:
+
+- **`register_remote_providers`** should load API credentials from the user profile and expose stub nodes that hand prompts to hosted inference providers, providing parity with on-disk weights.
+- **`configure_accelerator_env`** can switch between CUDA, ROCm, DirectML, or CPU-only execution based on detected hardware, matching the environment management performed in `main.py` while remaining portable to other projects.【F:main.py†L117-L140】
+- **`start_prompt_worker_thread`** demonstrates how to keep the UI responsive while heavier graph executions run asynchronously, mirroring ComfyUI’s daemon worker loop.【F:main.py†L156-L234】

--- a/docs/specs/user_responsibilities_spec.md
+++ b/docs/specs/user_responsibilities_spec.md
@@ -1,0 +1,48 @@
+# User Responsibilities Specification
+
+## Scope
+Captures the minimal steps end users must perform after installing ComfyUI via any distribution so support teams can provide consistent onboarding guidance.
+
+## Model Asset Provisioning
+- Users must supply their own Stable Diffusion checkpoints, VAEs, LoRAs, embeddings, and other models by copying them into the corresponding subdirectories under `models/`. README instructions explicitly call out `models/checkpoints` and `models/vae` as mandatory placements.【F:README.md†L174-L200】
+
+## Optional Path Customization
+- Advanced users can rename `extra_model_paths.yaml.example` to `extra_model_paths.yaml` and edit it to point at shared model folders or additional custom node directories. Desktop bundles should highlight this mechanism for users with existing model libraries.【F:README.md†L178-L180】【F:extra_model_paths.yaml.example†L1-L47】
+
+## Launching the Application
+- After models are in place, users launch the packaged runtime (either a native executable or `python main.py`). The startup sequence automatically prepares directories, loads custom nodes, and starts the prompt server, so no further manual configuration is required.【F:main.py†L25-L350】
+
+## Keeping Installations Updated
+- Portable and installer distributions may provide helper scripts (e.g., `update_comfyui.bat`) or expose the `--windows-standalone-build` flag to refresh bundled components. Users should follow distribution-specific instructions to stay current between official release packages.【F:main.py†L297-L308】
+
+## Reference First-Run Checklist
+Distributors can embed an interactive checklist to confirm end users have staged both local and remote assets before starting the server.
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+def confirm_first_run() -> None:
+    checkpoints = Path("models/checkpoints")
+    if not any(checkpoints.glob("*.safetensors")):
+        print("⚠️  Add at least one checkpoint to models/checkpoints")
+
+    extra_path = Path("extra_model_paths.yaml")
+    if extra_path.exists():
+        print("✅ Custom model paths configured")
+    else:
+        print("ℹ️  Create extra_model_paths.yaml to reference shared or remote stores")
+
+    remote_cfg = Path("user/remote_endpoints.yaml")
+    if remote_cfg.exists():
+        print("✅ Remote inference endpoints detected")
+    else:
+        print("ℹ️  Optional: define user/remote_endpoints.yaml for API-based models")
+
+
+if __name__ == "__main__":
+    confirm_first_run()
+```
+
+Pairing this checklist with onboarding docs helps non-technical users understand that model files are user-supplied and that optional remote providers require separate credentials, reinforcing the expectations documented in the README.【F:README.md†L174-L200】

--- a/docs/specs/windows_portable_spec.md
+++ b/docs/specs/windows_portable_spec.md
@@ -1,0 +1,56 @@
+# Windows Portable Package Specification
+
+## Scope
+Documents the expectations for the Windows portable 7z archive so release engineers can verify that the bundle remains fully self-contained and aligned with core releases.
+
+## Distribution Format
+- The README links a direct download to `ComfyUI_windows_portable_nvidia.7z`, positioning the archive as a portable option that tracks the latest commits and runs on NVIDIA GPUs or CPU-only systems.【F:README.md†L168-L176】
+
+## Bundled Contents
+- The archive must include a full Python runtime, a preinstalled copy of ComfyUI with dependencies from `requirements.txt`, launch scripts (`run_nvidia_gpu.bat`, etc.), and the default directory tree under `ComfyUI\models` plus `input`, `output`, and `temp` directories so no additional setup is required after extraction.【F:requirements.txt†L1-L30】【F:folder_paths.py†L16-L83】
+
+## Model Placement Guidance
+- Documentation instructs users to copy Stable Diffusion checkpoints into `ComfyUI\models\checkpoints` immediately after extraction. The archive should therefore ship with that path pre-created and referenced in any included README or helper scripts.【F:README.md†L174-L180】
+
+## Shared Model Support
+- The bundle includes `extra_model_paths.yaml.example` so users can rename it and point ComfyUI at shared model directories across other UIs, avoiding duplication on portable drives.【F:README.md†L178-L180】【F:extra_model_paths.yaml.example†L1-L47】
+
+## Update Mechanism
+- Windows standalone launches may pass `--windows-standalone-build`, triggering the updater bridge in `main.py` to refresh the packaged updater binaries. Portable distributions should either expose this flag or document how to run `update\update_comfyui.bat` to stay current between archive refreshes.【F:main.py†L297-L308】
+
+## Reference Packing Script
+The example below demonstrates how to assemble a portable archive that mirrors the official distribution while leaving hooks for alternative model sources.
+
+```powershell
+$ErrorActionPreference = 'Stop'
+
+$root = "C:\\ComfyUI-Portable"
+$python = "$root\\python"
+
+New-Item -ItemType Directory -Force -Path $root | Out-Null
+
+Copy-Item -Recurse -Force .\ComfyUI $root
+Copy-Item -Recurse -Force .\python_embeded $python
+
+& "$python\\python.exe" -m pip install --upgrade pip
+& "$python\\python.exe" -m pip install -r "$root\\ComfyUI\\requirements.txt"
+
+$modelFolders = @(
+    "models\\checkpoints",
+    "models\\vae",
+    "models\\loras",
+    "input",
+    "output",
+    "temp"
+)
+
+foreach ($folder in $modelFolders) {
+    New-Item -ItemType Directory -Force -Path (Join-Path $root "ComfyUI\\$folder") | Out-Null
+}
+
+Set-Content -Path "$root\\ComfyUI\\user\\remote_endpoints.yaml" -Value "sdxl: https://api.example.com/v1/inference"
+
+Compress-Archive -Path "$root\\*" -DestinationPath "ComfyUI_windows_portable_custom.7z"
+```
+
+Replace the remote endpoint placeholder with organisation-specific APIs when bundling hybrid local/remote experiences, and ensure the generated archive preserves the folder casing expected by `folder_paths.py` when extracted on Windows.【F:folder_paths.py†L16-L83】


### PR DESCRIPTION
## Summary
- add a desktop startup sequence spec that traces the Electron launcher from spawning main.py through prompting the UI to load
- link the new startup reference from the architecture and desktop distribution indexes so packaging teams can find it quickly

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c5db47af348328b8fdd884e38614bc